### PR TITLE
Add replyTo command.

### DIFF
--- a/nodejs-nodemailer-outlook.js
+++ b/nodejs-nodemailer-outlook.js
@@ -18,7 +18,6 @@ module.exports.sendEmail = function (options) {
     });
 transporter.sendMail({
     from: options.from,
-    sender: options.sender,
     replyTo: options.replyTo,
     to: options.to,
     subject: options.subject,

--- a/nodejs-nodemailer-outlook.js
+++ b/nodejs-nodemailer-outlook.js
@@ -18,6 +18,7 @@ module.exports.sendEmail = function (options) {
     });
 transporter.sendMail({
     from: options.from,
+    sender: options.sender,
     to: options.to,
     subject: options.subject,
     cc:options.cc,

--- a/nodejs-nodemailer-outlook.js
+++ b/nodejs-nodemailer-outlook.js
@@ -19,6 +19,7 @@ module.exports.sendEmail = function (options) {
 transporter.sendMail({
     from: options.from,
     sender: options.sender,
+    replyTo: options.replyTo,
     to: options.to,
     subject: options.subject,
     cc:options.cc,


### PR DESCRIPTION
Fixes #6 #3

This add the ability to have a reply-to user set other than the sender/from user.

I also tested out adding sender and the currently implemented from- and wasn't able to get either to work with my companies office365 setup. From what I read it's not possible to send email via outlook as anyone but yourself without the use of (seemingly deprecated) 3rd party plugins.